### PR TITLE
python tweaks to run on my ubuntu 16.04

### DIFF
--- a/steamfootbridge/config.py
+++ b/steamfootbridge/config.py
@@ -43,7 +43,7 @@ class Configuration:
         self._userid, __wine_steam_userconfig_file__)
 
   def _determine_current_user(self):
-    directories = os.listdir(self._wine_steam_path + __wine_steam_user_directories__)
+    directories = os.listdir(self._wine_steam_path.decode() + __wine_steam_user_directories__)
     if len(directories) == 0:
       raise StandardException("No users found!  Have you logged into Wine Steam?")
     elif len(directories) > 1:
@@ -77,5 +77,5 @@ class Configuration:
       raise StandardException("Unable to determine the SteamPath")
     if self._wine_steam_windows_executable == None:
       raise StandardException("Unable to determine the SteamExe")
-    self._wine_steam_path = string.strip(subprocess.check_output(["winepath",
-      self._wine_steam_windows_path]))
+    self._wine_steam_path = subprocess.check_output(["winepath",
+      self._wine_steam_windows_path]).strip()


### PR DESCRIPTION
Tweaks to fix errors on my machine.

Not looked at this very close yet - I seem to have other issues where running wine steam disconnects my native steam.

AFAIK I only have python 2.7 and 3.5 - it looks like steamfootbridge is running on my python 3.5 - odd as string.strip seems to exist in 2.7, which is my systems default `python`